### PR TITLE
Temporary solution to mux issue

### DIFF
--- a/src/act4e_mcdp/coords.py
+++ b/src/act4e_mcdp/coords.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Generic, Literal, Optional, Sequence, TypeVar, final
 
-from mcdp_utils_misc import BoolLike, not_true
+# from mcdp_utils_misc import BoolLike, not_true
 
 __all__ = [
     "ComposeList",
@@ -524,14 +524,16 @@ class InvalidCoords(ValueError):
     pass
 
 
-def is_valid_coords(c: "Coords") -> BoolLike:
+# def is_valid_coords(c: "Coords") -> BoolLike:
+def is_valid_coords(c: "Coords") -> bool:
     if isinstance(c, (CoordsIdentity, CoordsConst)):
         return True
     if isinstance(c, CoordsComp):
         return is_valid_coords(c.rest)
     if isinstance(c, ComposeList):  # type: ignore
         return all(is_valid_coords(x) for x in c.components)
-    return not_true(f"Invalid coords type {type(c).__name__}")
+    # return not_true(f"Invalid coords type {type(c).__name__}")
+    return False
 
 
 class CCOMapValue(CoordsConcreteOp[object]):

--- a/src/act4e_mcdp/solution_interface.py
+++ b/src/act4e_mcdp/solution_interface.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from fractions import Fraction
 from typing import Generic, Optional, TypeVar, final, overload
 
-from mcdp_maps_reg import cco_map_value
+# from mcdp_maps_reg import cco_map_value
 from .posets import Interval, LowerSet, Numbers, PosetProduct, UpperSet
 from .primitivedps import (
     AmbientConversion,
@@ -808,23 +808,23 @@ class DPSolverInterface(ABC):
 
     # Mux
 
-    def solve_dp_FixFunMinRes_Mux(
-        self, dp: Mux, query: FixFunMinResQuery[object]
-    ) -> Interval[UpperSet[object]]:
-        cco = cco_map_value  # FIXME
+    # def solve_dp_FixFunMinRes_Mux(
+    #     self, dp: Mux, query: FixFunMinResQuery[object]
+    # ) -> Interval[UpperSet[object]]:
+    #     cco = cco_map_value  # FIXME
 
-        r = dp.coords.get_it(query.functionality, cco=cco)  # type: ignore
-        return Interval.degenerate(UpperSet.principal(r))
+    #     r = dp.coords.get_it(query.functionality, cco=cco)  # type: ignore
+    #     return Interval.degenerate(UpperSet.principal(r))
 
-        raise NotImplementedError
+    #     raise NotImplementedError
 
-    def solve_dp_FixResMaxFun_Mux(
-        self, dp: Mux, query: FixResMaxFunQuery[object]
-    ) -> Interval[LowerSet[object]]:
-        cco = cco_map_value  # FIXME
+    # def solve_dp_FixResMaxFun_Mux(
+    #     self, dp: Mux, query: FixResMaxFunQuery[object]
+    # ) -> Interval[LowerSet[object]]:
+    #     cco = cco_map_value  # FIXME
 
-        r = dp.coords2.get_it(query.resources, cco=cco)  # type: ignore
-        return Interval.degenerate(LowerSet.principal(r))
+    #     r = dp.coords2.get_it(query.resources, cco=cco)  # type: ignore
+    #     return Interval.degenerate(LowerSet.principal(r))
 
     def solve_dp_FixFunMinRes_M_Fun_MultiplyMany_DP(
         self, dp: M_Fun_MultiplyMany_DP, query: FixFunMinResQuery[Decimal]


### PR DESCRIPTION
Quickly created a working version by commenting out the (maybe) unfinished solution templates `solve_dp_FixFunMinRes_Mux` and `solve_dp_FixResMaxFun_Mux`. Also removes usage of missing self-defined `BoolLike` class in `/src/act4e_mcdp/coords.py`.

A better quick solution is probably given by students [in this pull request](https://github.com/ACT4E/ACT4E-mcdp/pull/5), where the solutions templates are quickly fixed and `BoolLike` is self-defined.

It seems the exercises this year do not touch either `coords` or `Mux`, so we can omit them for now.